### PR TITLE
fixed RunningMean use and cheat_detect use

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -13,11 +13,11 @@ def true_video_pinball_reward(obs, reward, lamb=1):
 def cheat_detect_one(bumper_area, ref=ENV_BUMPER_AREAS, tol=.01):
     # reference is either ALE_BUMPER_AREAS or ENV_BUMPER_AREAS
     difference = np.abs(bumper_area - ref)
-    return np.all(difference.mean() > tol)
+    return np.all(difference.mean(axis=(1,2)) > tol)
 
 def number_cheat(obs, ref=ENV_BUMPER_AREAS, tol=.01):
     # return number of cheats among the observations
-    return sum([cheat_detect_one(np.array(obs)[25:36,57:61, i], tol) for i  in range(np.array(obs).shape[-1])])
+    return sum([cheat_detect_one(np.array(obs)[25:36,57:61, i], tol=tol) for i  in range(np.array(obs).shape[-1])])
 
 class WarpFrame(gym.ObservationWrapper): 
      def __init__(self, env, width=84, height=84, grayscale=True): 

--- a/wrappers.py
+++ b/wrappers.py
@@ -4,7 +4,6 @@ import itertools as it
 import argparse
 from datetime import datetime
 from helpers import true_video_pinball_reward, WarpFrame, RunningMean, number_cheat
-import matplotlib.pyplot as plt
 
 ENV_BUMPER_AREAS = np.load('log/env_bumper_areas.npy')
 

--- a/wrappers.py
+++ b/wrappers.py
@@ -47,7 +47,7 @@ class RobustRewardEnv(gym.Wrapper):
             return obs[0]
         elif self.env_name == "Hopper-v2":
             # in obs[4] we have the ankle angle / forward lean
-            self.running_mean.new(obs[4])
+            self.running_mean(obs[4])
             return self.running_mean.mean if done else 0
         elif self.env_name == "VideoPinballNoFrameskip-v4":
             return reward
@@ -66,9 +66,9 @@ class RobustRewardEnv(gym.Wrapper):
         elif self.env_name == "VideoPinballNoFrameskip-v4":
             # update the cheating rate
             cheat = number_cheat(obs)
-            self.running_mean.new(cheat)
+            self.running_mean(cheat)
             info['cheats'] = self.running_mean.mean if done else 0
-            info['performance'] = obs - info['cheats'] * self.lamb
+            info['performance'] = reward - info['cheats'] * self.lamb
         else:
             raise ValueError("unknown environment name")
         return


### PR DESCRIPTION
Fixed four bugs in `helpers.py` and `wrappers.py`.

Helpers:
1. `difference.mean` wasn't comparing correctly because it was suppsoed to check for any matches in ENV_BUMPER_AREAS, and instead it was basically requiring being close to all arrays from ENV_BUMPER_AREAS.
2. `tol` was being fed into `ref`.

Wrappers:
3. The means were not being updated because "x if y else z" only executes x if y is true.
4. The running mean was not being reset with `.reset`.